### PR TITLE
Chat: Force page to pre-fill window

### DIFF
--- a/chat/index.html
+++ b/chat/index.html
@@ -7,10 +7,14 @@
             shard="https://cl1.widgetbot.io"
             server="461495552039714817"
             channel="461495552039714819"
-            height="100%"
-            width="100%"
+			width="100%"
+			height="98%"
         >
         </widgetbot>
     </body>
     <script src="https://cdn.jsdelivr.net/npm/@widgetbot/html-embed"></script>
+	<script>
+	document.getElementsByTagName("HTML")[0].style.height = "100%";
+	document.getElementsByTagName("BODY")[0].style.height = "100%";
+	</script>
 </html>


### PR DESCRIPTION
This allows the page to assume it is the full size of the window without using clear; both and an excess of other CSS parameters, then fills the chat in to 98% in order to avoid the browser falsely assuming a scrollbar is required.